### PR TITLE
Check for 'type' in dictionary

### DIFF
--- a/swugenerator/generator.py
+++ b/swugenerator/generator.py
@@ -123,7 +123,7 @@ class SWUGenerator:
 
                 new.fullfilename = new_path
             # compression cannot be used with delta, because it has own compressor
-            elif entry["type"] and entry["type"] == "delta":
+            elif "type" in entry and entry["type"] == "delta":
                 cmd = [
                     "zck",
                     "-u",


### PR DESCRIPTION
If the type key is missing from an entry, it raises a KeyError exception