### PR TITLE
Fix zstd compression config handling

### DIFF
--- a/swugenerator/generator.py
+++ b/swugenerator/generator.py
@@ -88,6 +88,7 @@ class SWUGenerator:
                     sys.exit(1)
 
                 new_path = os.path.join(self.temp.name, new.newfilename) + "." + cmp
+                os.makedirs(os.path.dirname(new_path), exist_ok=True)
                 new.newfilename = new.newfilename + "." + cmp
                 if cmp == "zlib":
                     cmd = [

--- a/swugenerator/generator.py
+++ b/swugenerator/generator.py
@@ -107,6 +107,7 @@ class SWUGenerator:
                         "-z",
                         "-k",
                         "-T0",
+                        "-f",
                         "-c",
                         new.fullfilename,
                         ">",


### PR DESCRIPTION
The following issues are fixed:
* Allow zstd to decompress symlinks. "... is a symbolic link, ignoring" warning.
* Temp directory for compressed image should be created first. Otherwise, you will get "Directory nonexistent" error.
* Clarified "Wrong compression algorithm:" error message to show the list of supported values in "compression" option.