### PR TITLE
Add support for PSS padding when signing with RSA

### DIFF
--- a/swugenerator/main.py
+++ b/swugenerator/main.py
@@ -119,16 +119,16 @@ def parse_signing_option(
         # Format : CMS,<private key>,<certificate used to sign>
         else:
             return SWUSignCMS(sign_parms[1], sign_parms[2], None, None)
-    if cmd == "RSA":
+    if cmd[:3] == "RSA":
         if len(sign_parms) not in (2, 3) or not all(sign_parms):
             raise InvalidSigningOption(
                 "RSA requires private key and an optional password file"
             )
-        # Format : RSA,<private key>,<file with password>
+        # Format : RSA(PSS),<private key>,<file with password>
         if len(sign_parms) == 3:
-            return SWUSignRSA(sign_parms[1], sign_parms[2])
-        # Format : RSA,<private key>
-        return SWUSignRSA(sign_parms[1], None)
+            return SWUSignRSA(sign_parms[1], sign_parms[2], pss=True if cmd == "RSAPSS" else False)
+        # Format : RSA(PSS),<private key>
+        return SWUSignRSA(sign_parms[1], None, pss=True if cmd == "RSAPSS" else False)
     if cmd == "PKCS11":
         # Format : PKCS11,<pin>
         if len(sign_parms) != 2 or not all(sign_parms):

--- a/swugenerator/swu_sign.py
+++ b/swugenerator/swu_sign.py
@@ -79,16 +79,21 @@ class SWUSignCMS(SWUSign):
 
 
 class SWUSignRSA(SWUSign):
-    def __init__(self, key, passin):
+    def __init__(self, key, passin, pss=False):
         super().__init__()
         self.type = "RSA"
         self.key = key
         self.passin = passin
+        if pss == True:
+            self.pss_args = ["-sigopt rsa_padding_mode:pss", "-sigopt rsa_pss_saltlen:-2"]
+        else:
+            self.pss_args = []
 
     def prepare_cmd(self, sw_desc_in, sw_desc_sig):
         self.signcmd = (
             ["openssl", "dgst", "-sha256", "-sign", self.key]
             + self.get_passwd_file_args()
+            + self.pss_args
             + ["-out", sw_desc_sig, sw_desc_in]
         )
 


### PR DESCRIPTION
SWUpdate supports both PKCS#1 and PSS padding with RSA but swugenerator only implements PKCS#1 padding. PSS padding support is therefore added in SWUSignRSA.
One can use the keyword RSAPSS to sign the sw-description file with RSA and PSS padding. For instance:
`-k RSAPSS,myprivatekey.pem`