### PR TITLE
signing: add environment variables to custom command

### DIFF
--- a/swugenerator/swu_sign.py
+++ b/swugenerator/swu_sign.py
@@ -99,8 +99,12 @@ class SWUSignCustom(SWUSign):
         self.type = "CUSTOM"
         self.custom = cmd.split()
 
-    def prepare_cmd(self, *_):
-        self.signcmd = copy.deepcopy(self.custom)
+    def prepare_cmd(self, sw_desc_in, sw_desc_sig):
+        self.signcmd = [
+            f"SW_DESC_IN={sw_desc_in}",
+            f"SW_DESC_SIG={sw_desc_sig}"
+        ]
+        self.signcmd += copy.deepcopy(self.custom)
 
 
 # Note: tested with Nitrokey HSM


### PR DESCRIPTION
Finding the right place for input and output for custom signing commands is hacky right now, because the right place is generated dynamically somewhere in /tmp.

Adding two environment variables makes it very easy in the future.

The two environment variables SW_DESC_IN and SW_DESC_SIG can be used from now on.