### PR TITLE
Add optional --module input argument when PCKS11 signing

### DIFF
--- a/swugenerator/main.py
+++ b/swugenerator/main.py
@@ -91,7 +91,7 @@ def parse_signing_option(
     CMS,<private key>,<certificate used to sign>
     RSA,<private key>,<file with password>
     RSA,<private key>
-    PKCS11,<pin>
+    PKCS11,<pin>[,<module>]
     CUSTOM,<custom command>
 
     Args:
@@ -130,10 +130,12 @@ def parse_signing_option(
         # Format : RSA,<private key>
         return SWUSignRSA(sign_parms[1], None)
     if cmd == "PKCS11":
-        # Format : PKCS11,<pin>
-        if len(sign_parms) != 2 or not all(sign_parms):
-            raise InvalidSigningOption("PKCS11 requires URI")
-        return SWUSignPKCS11(sign_parms[1])
+        # Format : PKCS11,<pin>[,<module>]
+        if len(sign_parms) not in (2, 3) or not all(sign_parms[0:2]):
+            raise InvalidSigningOption("PKCS11 requires pin and optional module path")
+        pin = sign_parms[1]
+        module = sign_parms[2] if len(sign_parms) == 3 else None
+        return SWUSignPKCS11(pin, module)
     if cmd == "CUSTOM":
         # Format : CUSTOM,<custom command>
         if len(sign_parms) < 2 or not all(sign_parms):
@@ -251,7 +253,7 @@ def parse_args(args: List[str]) -> None:
             One of :
             CMS,<private key>,<certificate used to sign>,<file with password if any>,<file with certs if any>
             RSA,<private key>,<file with password if any>
-            PKCS11,<pin>
+            PKCS11,<pin>[,<module>]
             CUSTOM,<custom command> """
         ),
     )

--- a/swugenerator/swu_sign.py
+++ b/swugenerator/swu_sign.py
@@ -107,11 +107,13 @@ class SWUSignCustom(SWUSign):
 
 # Note: tested with Nitrokey HSM
 class SWUSignPKCS11(SWUSign):
-    def __init__(self, pin):
+    def __init__(self, pin, module=None):
         super().__init__()
         self.type = "PKCS11"
-        self.custom = ["--pin"]
-        self.custom.append(pin)
+        self.custom = []
+        if module:
+            self.custom.extend(["--module", module])
+        self.custom.extend(["--pin", pin])
 
     def prepare_cmd(self, sw_desc_in, sw_desc_sig):
         self.signcmd = [

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -103,6 +103,7 @@ SIGNING_TEST_PARAMETERS = [
     ("RSA,foo,bar", SWUSignRSA("foo", "bar")),
     ("RSA,foo", SWUSignRSA("foo", None)),
     ("PKCS11,foo", SWUSignPKCS11("foo")),
+    ("PKCS11,foo,bar", SWUSignPKCS11("foo", "bar")),
     ("CUSTOM,foo", SWUSignCustom("foo")),
 ]
 


### PR DESCRIPTION
swugenerator uses pkcs11-tool when PKCS11 signing is requested.
This tool allows specifying the module to load using the --module argument.

For example, when SoftHSM is used, the module must be specified.

This feature could be implemented using a CUSTOM command option. However, since pkcs11-tool is already available and integrated into the signing process, this solution is cleaner and more straightforward.

Therefore, a second optional parameter is added when PKCS11 signing is used.
If the module is not specified, swugenerator behaves as before.

This feature has been tested in a Debian Bookworm x86 system:

`jfpastrana@t14-jfpastrana:~/Documents/LX/swupdate-example$ swugenerator --no-compress -s sw-description.in -k PKCS11,1234,/usr/lib/softhsm/libsofthsm2.so -o tmp/signed.swu -a artifactory create`

`Using slot 0 with a present token (0x464d7d15)`
`Using signature algorithm SHA256-RSA-PKCS`