### PR TITLE
Enable -engine and -keyform options in openssl cms

### DIFF
--- a/swugenerator/main.py
+++ b/swugenerator/main.py
@@ -84,6 +84,7 @@ def parse_config_file(config_file_arg: str) -> dict:
 def parse_signing_option(
     sign_arg: str,
     engine: str = None,
+    keyform: str = None,
 ) -> Union[SWUSignCMS, SWUSignRSA, SWUSignPKCS11, SWUSignCustom]:
     """Parses signgning option passed by user. Valid options can be found below.
 
@@ -98,6 +99,7 @@ def parse_signing_option(
     Args:
         sign_arg (str): argument passed by user
         engine (str): OpenSSL engine to use for signing (e.g., pkcs11)
+        keyform (str): Key format to use for signing (e.g., engine)
 
     Raises:
         InvalidSigningOption: If option passed by user is invalid
@@ -114,13 +116,13 @@ def parse_signing_option(
             )
         # Format : CMS,<private key>,<certificate used to sign>,<file with password>,<file with certs>
         if len(sign_parms) == 5:
-            return SWUSignCMS(sign_parms[1], sign_parms[2], sign_parms[3], sign_parms[4], engine)
+            return SWUSignCMS(sign_parms[1], sign_parms[2], sign_parms[3], sign_parms[4], engine, keyform)
         # Format : CMS,<private key>,<certificate used to sign>,<file with password>
         elif len(sign_parms) == 4:
-            return SWUSignCMS(sign_parms[1], sign_parms[2], sign_parms[3], None, engine)
+            return SWUSignCMS(sign_parms[1], sign_parms[2], sign_parms[3], None, engine, keyform)
         # Format : CMS,<private key>,<certificate used to sign>
         else:
-            return SWUSignCMS(sign_parms[1], sign_parms[2], None, None, engine)
+            return SWUSignCMS(sign_parms[1], sign_parms[2], None, None, engine, keyform)
     if cmd == "RSA":
         if len(sign_parms) not in (2, 3) or not all(sign_parms):
             raise InvalidSigningOption(
@@ -176,9 +178,9 @@ def create_swu(args: argparse.Namespace) -> None:
     # Add current working directory to search path
     args.artifactory.append(Path(os.getcwd()))
 
-    # Pass engine to parse_signing_option if sign is set
+    # Pass engine and keyform to parse_signing_option if sign is set
     if hasattr(args, 'sign') and args.sign and isinstance(args.sign, str):
-        args.sign = parse_signing_option(args.sign, args.engine)
+        args.sign = parse_signing_option(args.sign, args.engine, args.keyform)
 
     swu = generator.SWUGenerator(
         args.sw_description,
@@ -256,6 +258,7 @@ def parse_args(args: List[str]) -> None:
             One of :
             CMS,<private key>,<certificate used to sign>,<file with password if any>,<file with certs if any>
                  -g, --engine ENGINE       OpenSSL engine to use for signing (e.g., pkcs11)
+                 -f, --keyform KEYFORM     Key format to use for signing (e.g., engine)
             RSA,<private key>,<file with password if any>
             PKCS11,<pin>
             CUSTOM,<custom command> """
@@ -318,6 +321,12 @@ def parse_args(args: List[str]) -> None:
         default=None,
         help=argparse.SUPPRESS,
     )
+    parser.add_argument(
+        "-f",
+        "--keyform",
+        default=None,
+        help=argparse.SUPPRESS,
+    )
 
     subparsers = parser.add_subparsers(
         title="command", help="command to be executed", required=True
@@ -327,7 +336,7 @@ def parse_args(args: List[str]) -> None:
 
     args = parser.parse_args(args)
     if hasattr(args, 'sign') and args.sign:
-        args.sign = parse_signing_option(args.sign, args.engine)
+        args.sign = parse_signing_option(args.sign, args.engine, args.keyform)
     args.func(args)
 
 

--- a/swugenerator/swu_sign.py
+++ b/swugenerator/swu_sign.py
@@ -37,7 +37,7 @@ class SWUSign:
 
     def sign(self):
         try:
-            subprocess.run(" ".join(self.signcmd), shell=True, check=True, text=True)
+            subprocess.run(self.signcmd, check=True, text=True)
         except subprocess.CalledProcessError:
             logging.critical(
                 "SWU cannot be signed, signing command was %s", self.signcmd

--- a/swugenerator/swu_sign.py
+++ b/swugenerator/swu_sign.py
@@ -46,7 +46,7 @@ class SWUSign:
 
 
 class SWUSignCMS(SWUSign):
-    def __init__(self, key, cert, passin, certfile, engine=None):
+    def __init__(self, key, cert, passin, certfile, engine=None, keyform=None):
         super().__init__()
         self.type = "CMS"
         self.key = key
@@ -54,6 +54,7 @@ class SWUSignCMS(SWUSign):
         self.passin = passin
         self.certfile = certfile
         self.engine = engine
+        self.keyform = keyform
 
     def prepare_cmd(self, sw_desc_in, sw_desc_sig):
         self.signcmd = [
@@ -69,6 +70,8 @@ class SWUSignCMS(SWUSign):
         ]
         if self.engine:
             self.signcmd += ["-engine", self.engine]
+        if self.keyform:
+            self.signcmd += ["-keyform", self.keyform]
         self.signcmd += [
             "-inkey",
             self.key,

--- a/swugenerator/swu_sign.py
+++ b/swugenerator/swu_sign.py
@@ -46,13 +46,14 @@ class SWUSign:
 
 
 class SWUSignCMS(SWUSign):
-    def __init__(self, key, cert, passin, certfile):
+    def __init__(self, key, cert, passin, certfile, engine=None):
         super().__init__()
         self.type = "CMS"
         self.key = key
         self.cert = cert
         self.passin = passin
         self.certfile = certfile
+        self.engine = engine
 
     def prepare_cmd(self, sw_desc_in, sw_desc_sig):
         self.signcmd = [
@@ -66,6 +67,8 @@ class SWUSignCMS(SWUSign):
             "-signer",
             self.cert,
         ]
+        if self.engine:
+            self.signcmd += ["-engine", self.engine]
         self.signcmd += [
             "-inkey",
             self.key,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -154,7 +154,7 @@ def test_invalid_signing_params_throws_exception_with_correct_msg(arg, exception
     assert exception_msg in error.value.args
 
 
-def test_parse_signing_option_cms_with_engine():
+def test_parse_signing_option_cms_with_engine_and_keyform():
     # Only engine
     obj = main.parse_signing_option("CMS,foo,bar,baz,qux", engine="myengine")
     assert isinstance(obj, SWUSignCMS)
@@ -164,11 +164,30 @@ def test_parse_signing_option_cms_with_engine():
     assert obj.passin == "baz"
     assert obj.certfile == "qux"
 
+    # Only keyform
+    obj = main.parse_signing_option("CMS,foo,bar,baz,qux", keyform="mykeyform")
+    assert isinstance(obj, SWUSignCMS)
+    assert obj.keyform == "mykeyform"
+    assert obj.key == "foo"
+    assert obj.cert == "bar"
+    assert obj.passin == "baz"
+    assert obj.certfile == "qux"
 
-    # Without engine
+    # Both engine and keyform
+    obj = main.parse_signing_option("CMS,foo,bar,baz,qux", engine="myengine", keyform="mykeyform")
+    assert isinstance(obj, SWUSignCMS)
+    assert obj.engine == "myengine"
+    assert obj.keyform == "mykeyform"
+    assert obj.key == "foo"
+    assert obj.cert == "bar"
+    assert obj.passin == "baz"
+    assert obj.certfile == "qux"
+
+    # Neither engine nor keyform
     obj = main.parse_signing_option("CMS,foo,bar,baz,qux")
     assert isinstance(obj, SWUSignCMS)
     assert obj.engine is None
+    assert obj.keyform is None
     assert obj.key == "foo"
     assert obj.cert == "bar"
     assert obj.passin == "baz"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -154,6 +154,27 @@ def test_invalid_signing_params_throws_exception_with_correct_msg(arg, exception
     assert exception_msg in error.value.args
 
 
+def test_parse_signing_option_cms_with_engine():
+    # Only engine
+    obj = main.parse_signing_option("CMS,foo,bar,baz,qux", engine="myengine")
+    assert isinstance(obj, SWUSignCMS)
+    assert obj.engine == "myengine"
+    assert obj.key == "foo"
+    assert obj.cert == "bar"
+    assert obj.passin == "baz"
+    assert obj.certfile == "qux"
+
+
+    # Without engine
+    obj = main.parse_signing_option("CMS,foo,bar,baz,qux")
+    assert isinstance(obj, SWUSignCMS)
+    assert obj.engine is None
+    assert obj.key == "foo"
+    assert obj.cert == "bar"
+    assert obj.passin == "baz"
+    assert obj.certfile == "qux"
+
+
 #### Parse args tests ####
 @pytest.fixture
 def mock_main_funcs(monkeypatch):


### PR DESCRIPTION
This change extends openssl cms to support the -engine and -keyform options, enabling the use of external cryptographic engines, most notably PKCS#11 for HSM or smart card integration.

By default, openssl cms can only use private keys stored in the filesystem.

In secure environments (e.g., using an HSM or SoftHSM), private keys and certificates are stored securely in a PKCS#11 token and never leave the device.

This change enables openssl cms to access private keys and certificates through the PKCS#11 engine, using URIs like:

`-inkey "pkcs11:token=MyToken;object=mykey;type=private"`

pkcs11-tool is a low-level utility that cannot interpret or work with X.509 certificates or CMS structures, and therefore cannot perform CMS signing. It is not a viable alternative for this use case.

I tested this feature in a Linux Debian x86 system using the following command:
`swugenerator -n -s sw-description.in -k "CMS,pkcs11:token=develhsm;object=dev,dev.crt" --engine pkcs11 --keyform engine -o artifact_signed.swu -a build-out -l DEBUG create`

`DEBUG:root:version = 1.0`
`DEBUG:root:hardware-compatibility = ['1.0']`
`DEBUG:root:reboot = False`
`DEBUG:root:filename = testfile1`
`DEBUG:root:filename = testfile2`
`DEBUG:root:New artifact testfile1`
`DEBUG:root:New artifact testfile2`
`Engine "pkcs11" set.`
`Enter PKCS#11 token PIN for develhsm:`

Also the previous functionality:

`swugenerator --no-compress -s sw-description -k CMS,private.key,public.cert.pem -o test.swu -a artifactory create`